### PR TITLE
Errors connecting to Hive api

### DIFF
--- a/Connection.js
+++ b/Connection.js
@@ -44,7 +44,8 @@ module.exports.command = async.queue(function (task, callback) {
         jar:module.exports.context.authToken,
         form: undefined,
         method: undefined,
-        qs:undefined
+        qs:undefined,
+        strictSSL:false
     };
 
     if (typeof task == 'object') {


### PR DESCRIPTION
strictSSL set to false as suggested by nosdod here: https://github.com/aklambeth/bg-hive-api/issues/5#issuecomment-255852463

This was due to errors TypeError: Cannot read property 'body' of undefined
from this issue https://github.com/aklambeth/bg-hive-api/issues/5

I was also having the same problem