### PR TITLE
Move endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var config = {
     },
 
     api : {
-        "Hive": "https://api.bgchlivehome.co.uk/v5",
+        "Hive": "https://api-prod.bgchprod.info/v5",
         "AlertMe" : "https://api.alertme.com/v5"
     }
 }


### PR DESCRIPTION
Hive seems to have moved their endpoint to : https://api-prod.bgchprod.info/v5

And are returning 503 from the previous endpoint.

Have tested locally.